### PR TITLE
Fix RuntimeError: a leaf Variable that requires grad has been used in…

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,7 +134,7 @@ def main():
                 emb[vocab.getIndex(word)] = glove_emb[glove_vocab.getIndex(word)]
         torch.save(emb, emb_file)
     # plug these into embedding matrix inside model
-    model.emb.weight.copy_(emb)
+    model.emb.weight.data.copy_(emb)
 
     model.to(device), criterion.to(device)
     if args.optim == 'adam':


### PR DESCRIPTION
I just tried to run the training locally, and met with the following error when not to freeze the embedding.

> Traceback (most recent call last):
>   File "main.py", line 189, in <module>
>     main()
>   File "main.py", line 138, in main
>     emb)
>   File "/Users/Jizg/git/treelstm.pytorch/treelstm/model.py", line 76, in __init__
>     self.emb.weight.copy_(init_emb)
> RuntimeError: a leaf Variable that requires grad has been used in an in-place operation.

I updated the main script a little bit and it seems to be OK now. 