### PR TITLE
Batch support for TreeLSTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,9 @@
-
 # Tree-Structured Long Short-Term Memory Networks
-This is a [PyTorch](http://pytorch.org/) implementation of Tree-LSTM as described in the paper [Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](http://arxiv.org/abs/1503.00075) by Kai Sheng Tai, Richard Socher, and Christopher Manning. On the semantic similarity task using the SICK dataset, this implementation reaches:
- - Pearson's coefficient: `0.8492` and MSE: `0.2842` using hyperparameters `--lr 0.010 --wd 0.0001 --optim adagrad --batchsize 25`
- - Pearson's coefficient: `0.8674` and MSE: `0.2536` using hyperparameters `--lr 0.025 --wd 0.0001 --optim adagrad --batchsize 25 --freeze_embed`
- - Pearson's coefficient: `0.8676` and MSE: `0.2532` are the numbers reported in the original paper.
- - Known differences include the way the gradients are accumulated (normalized by batchsize or not).
 
-### Requirements
-- Python (tested on **3.6.5**, should work on **>=2.7**)
-- Java >= 8 (for Stanford CoreNLP utilities)
-- Other dependencies are in `requirements.txt`
-Note: Currently works with PyTorch 0.4.0. Switch to the `pytorch-v0.3.1` branch if you want to use PyTorch 0.3.1.
+The [original implementation](https://github.com/dasguptar/treelstm.pytorch) for paper [Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](http://arxiv.org/abs/1503.00075) doesn't support batch calculation of TreeLSTM.
 
-### Usage
-Before delving into how to run the code, here is a quick overview of the contents:
- - Use the script `fetch_and_preprocess.sh` to download the [SICK dataset](http://alt.qcri.org/semeval2014/task1/index.php?id=data-and-tools), [Stanford Parser](http://nlp.stanford.edu/software/lex-parser.shtml) and [Stanford POS Tagger](http://nlp.stanford.edu/software/tagger.shtml), and [Glove word vectors](http://nlp.stanford.edu/projects/glove/) (Common Crawl 840) -- **Warning:** this is a 2GB download!), and additionally preprocees the data, i.e. generate dependency parses using [Stanford Neural Network Dependency Parser](http://nlp.stanford.edu/software/nndep.shtml).
- - `main.py`does the actual heavy lifting of training the model and testing it on the SICK dataset. For a list of all command-line arguments, have a look at `config.py`.
-     - The first run caches GLOVE embeddings for words in the SICK vocabulary. In later runs, only the cache is read in during later runs.
-     - Logs and model checkpoints are saved to the `checkpoints/` directory with the name specified by the command line argument `--expname`.
-
-Next, these are the different ways to run the code here to train a TreeLSTM model.
-#### Local Python Environment
-If you have a working Python3 environment, simply run the following sequence of steps:
+To run the model with batch TreeLSTM:
 ```
-- bash fetch_and_preprocess.sh
-- pip install -r requirements.txt
-- python main.py
+- python main.py --use_batch --batchsize 25
 ```
-#### Pure Docker Environment
-If you want to use a Docker container, simply follow these steps:
-```
-- docker build -t treelstm .
-- docker run -it treelstm bash
-- bash fetch_and_preprocess.sh
-- python main.py
-```
-#### Local Filesystem + Docker Environment
-If you want to use a Docker container, but want to persist data and checkpoints in your local filesystem, simply follow these steps:
-```
-- bash fetch_and_preprocess.sh
-- docker build -t treelstm .
-- docker run -it --mount type=bind,source="$(pwd)",target="/root/treelstm.pytorch" treelstm bash
-- python main.py
-```
-**NOTE**: Setting the environment variable OMP_NUM_THREADS=1 usually gives a speedup on the CPU. Use it like `OMP_NUM_THREADS=1 python main.py`. To run on a GPU, set the CUDA_VISIBLE_DEVICES instead. Usually, CUDA does not give much speedup here, since we are operating at a batchsize of `1`.
-
-### Notes
- - (**Apr 02, 2018**) Added Dockerfile
- - (**Apr 02, 2018**) Now works on **PyTorch 0.3.1** and **Python 3.6**, removed dependency on **Python 2.7**
- - (**Nov 28, 2017**) Added **frozen embeddings**, closed gap to paper.
- - (**Nov 08, 2017**) Refactored model to get **1.5x - 2x speedup**.
- - (**Oct 23, 2017**) Now works with **PyTorch 0.2.0**.
- - (**May 04, 2017**) Added support for **sparse tensors**. Using the `--sparse` argument will enable sparse gradient updates for `nn.Embedding`, potentially reducing memory usage.
-     - There are a couple of caveats, however, viz. weight decay will not work in conjunction with sparsity, and results from the original paper might not be reproduced using sparse embeddings.
-
-### Acknowledgements
-Shout-out to [Kai Sheng Tai](https://github.com/kaishengtai/) for the [original LuaTorch implementation](https://github.com/stanfordnlp/treelstm), and to the [Pytorch team](https://github.com/pytorch/pytorch#the-team) for the fun library.
-
-### Contact
-[Riddhiman Dasgupta](https://researchweb.iiit.ac.in/~riddhiman.dasgupta/)
-
-*This is my first PyTorch based implementation, and might contain bugs. Please let me know if you find any!*
-
-### License
-MIT
+which should give you exact results as without batch, but much faster in training and inference.

--- a/config.py
+++ b/config.py
@@ -44,6 +44,7 @@ def parse_args():
     cuda_parser = parser.add_mutually_exclusive_group(required=False)
     cuda_parser.add_argument('--cuda', dest='cuda', action='store_true')
     cuda_parser.add_argument('--no-cuda', dest='cuda', action='store_false')
+    cuda_parser.add_argument('--use_batch', dest='use_batch', action='store_true')
     parser.set_defaults(cuda=True)
 
     args = parser.parse_args()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,49 @@
+import torch
+from .tree import Tree
+from .model import ChildSumTreeLSTM
+
+t1_n1 = Tree()
+t1_n1.idx = 0
+t1_n2 = Tree()
+t1_n2.idx = 1
+t1_n1.add_child(t1_n2)
+t1_n2.parent = t1_n1
+tree1 = {0: t1_n1, 1: t1_n2}
+
+t2_n1 = Tree()
+t2_n1.idx = 0
+t2_n2 = Tree()
+t2_n2.idx = 1
+t2_n3 = Tree()
+t2_n3.idx = 2
+t2_n4 = Tree()
+t2_n4.idx = 3
+t2_n3.add_child(t2_n1)
+t2_n3.add_child(t2_n2)
+t2_n1.parent = t2_n3
+t2_n2.parent = t2_n3
+t2_n2.add_child(t2_n4)
+t2_n4.parent=t2_n2
+tree2 = {0: t2_n1, 1: t2_n2, 2: t2_n3, 3: t2_n4}
+trees = [tree1, tree2]
+
+tensor1 = torch.Tensor(2, 10)
+tensor2 = torch.Tensor(4, 10)
+tensors = [tensor1, tensor2]
+
+tree_lstm = ChildSumTreeLSTM(10, 4)
+
+state1, hidden1 = tree_lstm(t1_n1, tensor1)
+state2, hidden2 = tree_lstm(t2_n3, tensor2)
+
+print("state1", state1)
+print("hidden1", hidden1)
+print("state2", state2)
+print("hidden2", hidden2)
+
+for tree in trees:
+    for idx, node in tree.items():
+        node.state = None
+batch_state, batch_hidden = tree_lstm(trees, tensors)
+print(batch_state)
+print(batch_hidden)

--- a/treelstm/__init__.py
+++ b/treelstm/__init__.py
@@ -1,10 +1,10 @@
 from . import Constants
 from .dataset import SICKDataset
 from .metrics import Metrics
-from .model import SimilarityTreeLSTM
+from .model import ChildSumTreeLSTM, SimilarityTreeLSTM
 from .trainer import Trainer
 from .tree import Tree
 from . import utils
 from .vocab import Vocab
 
-__all__ = [Constants, SICKDataset, Metrics, SimilarityTreeLSTM, Trainer, Tree, Vocab, utils]
+__all__ = [Constants, ChildSumTreeLSTM, SICKDataset, Metrics, SimilarityTreeLSTM, Trainer, Tree, Vocab, utils]

--- a/treelstm/dataset.py
+++ b/treelstm/dataset.py
@@ -37,6 +37,18 @@ class SICKDataset(data.Dataset):
         label = deepcopy(self.labels[index])
         return (ltree, lsent, rtree, rsent, label)
 
+    def get_next_batch(self, index, batch_size):
+        ltrees, rtrees, lsents, rsents, labels = [], [], [], [], []
+        for i in range(index, index+batch_size):
+            if i < self.size:
+                ltree, lsent, rtree, rsent, label = self.__getitem__(i)
+                ltrees.append(ltree[1])
+                rtrees.append(rtree[1])
+                lsents.append(lsent)
+                rsents.append(rsent)
+                labels.append(label)
+        return (ltrees, lsents, rtrees, rsents, labels)
+
     def read_sentences(self, filename):
         with open(filename, 'r') as f:
             sentences = [self.read_sentence(line) for line in tqdm(f.readlines())]
@@ -77,7 +89,7 @@ class SICKDataset(data.Dataset):
                     else:
                         prev = tree
                         idx = parent
-        return root
+        return (root, trees)
 
     def read_labels(self, filename):
         with open(filename, 'r') as f:

--- a/treelstm/model.py
+++ b/treelstm/model.py
@@ -1,14 +1,19 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.autograd import Variable
+from torch import cuda
 
 from . import Constants
+from .tree import Tree
 
 
 # module for childsumtreelstm
 class ChildSumTreeLSTM(nn.Module):
     def __init__(self, in_dim, mem_dim):
         super(ChildSumTreeLSTM, self).__init__()
+        self.bsz = 128
+        self.max_num_children = 10
         self.in_dim = in_dim
         self.mem_dim = mem_dim
         self.ioux = nn.Linear(self.in_dim, 3 * self.mem_dim)
@@ -17,6 +22,9 @@ class ChildSumTreeLSTM(nn.Module):
         self.fh = nn.Linear(self.mem_dim, self.mem_dim)
 
     def node_forward(self, inputs, child_c, child_h):
+        # inputs: in_dim
+        # child_c: num_children * mem_dim
+        # child_h: num_children * mem_dim
         child_h_sum = torch.sum(child_h, dim=0, keepdim=True)
 
         iou = self.ioux(inputs) + self.iouh(child_h_sum)
@@ -33,7 +41,32 @@ class ChildSumTreeLSTM(nn.Module):
         h = torch.mul(o, F.tanh(c))
         return c, h
 
+    def batch_node_forward(self, inputs, child_c, child_h, num_children):
+        # inputs: bsz * in_dim
+        # child_c: bsz * max_num_child * in_dim
+        # child_h: bsz * max_num_child * in_dim
+        # num_children: bsz * num_children
+        bsz, max_num_children, _ = child_c.size()
+        child_h_sum = torch.sum(child_h, dim=1, keepdim=False)
+
+        iou = self.ioux(inputs) + self.iouh(child_h_sum)
+        i, o, u = torch.split(iou, iou.size(1) // 3, dim=1)
+        i, o, u = F.sigmoid(i), F.sigmoid(o), F.tanh(u)
+
+        fh, fx = self.fh(child_h), self.fx(inputs)
+        for idx in range(bsz):
+            fh[idx, :num_children[idx]] += fx[idx].repeat(num_children[idx], 1)
+        f = F.sigmoid(fh)
+
+        fc = torch.mul(f, child_c)
+
+        c = torch.mul(i, u) + torch.sum(fc, dim=1, keepdim=False)
+        h = torch.mul(o, F.tanh(c))
+        return c, h
+
     def forward(self, tree, inputs):
+        if isinstance(tree, list):
+            return self.batch_forward(tree, inputs)
         for idx in range(tree.num_children):
             self.forward(tree.children[idx], inputs)
 
@@ -46,6 +79,140 @@ class ChildSumTreeLSTM(nn.Module):
 
         tree.state = self.node_forward(inputs[tree.idx], child_c, child_h)
         return tree.state
+
+
+    def update_leaf_states(self, trees, inputs):
+        queue = []
+        for tree_idx, tree in enumerate(trees):
+            for node_idx, node in tree.items():
+                if node.num_children == 0:
+                    node.visited = True
+                    child_c = Variable(torch.zeros(1, self.mem_dim), requires_grad=True)
+                    child_h = Variable(torch.zeros(1, self.mem_dim), requires_grad=True)
+                    if cuda.is_available():
+                        child_c = child_c.cuda()
+                        child_h = child_h.cuda()
+                    input = inputs[tree_idx][node_idx]
+                    queue.append((tree_idx, node_idx, input, child_c, child_h))
+
+        head = 0
+        while head < len(queue):
+            idxes, encoder_inputs, children_c, children_h = [], [], [], []
+            while head < len(queue) and len(encoder_inputs) < self.bsz:
+                tree_idx, node_idx, input, child_c, child_h = queue[head]
+                encoder_inputs.append(input.unsqueeze(0))
+                children_c.append(child_c.unsqueeze(0))
+                children_h.append(child_h.unsqueeze(0))
+                head += 1
+            encoder_inputs = torch.cat(encoder_inputs, dim=0)
+            children_c = torch.cat(children_c, dim=0)
+            children_h = torch.cat(children_h, dim=0)
+            num_children = [1] * len(encoder_inputs)
+            #print('leaf', len(encoder_inputs))
+            batch_c, batch_h = self.batch_node_forward(encoder_inputs, children_c, children_h, num_children)
+            for i in range(batch_c.shape[0]):
+                idx = head - batch_c.shape[0] + i
+                tree_idx, node_idx, _, _, _ = queue[idx]
+                trees[tree_idx][node_idx].state = (batch_c[i], batch_h[i])
+        for tree_idx, tree in enumerate(trees):
+            for node_idx, node in tree.items():
+                if node.num_children == 0:
+                    assert node.state is not None
+        return queue
+
+
+    def update_internal_node_states(self, trees, inputs, queue):
+        head = 0
+        num_internal_nodes, depth = 0, 1
+        while head < len(queue):
+            # find updatable parent nodes, and push to the end of queue
+            prev_num_nodes = len(queue)
+            while head < prev_num_nodes:
+                tree_idx, node_idx, _, _, _ = queue[head]
+                parent_node = trees[tree_idx][node_idx].parent
+                if parent_node is not None and not parent_node.visited:
+                    can_visit = True
+                    children_c, children_h = [], []
+                    for child_node in parent_node.children:
+                        if child_node.state is None:
+                            can_visit = False
+                            break
+                        else:
+                            c, h = child_node.state
+                            children_c.append(c.unsqueeze(0))
+                            children_h.append(h.unsqueeze(0))
+                    if can_visit:
+                        parent_node.visited = True
+                        children_c_var = Variable(torch.zeros(self.max_num_children, self.mem_dim),
+                                                  requires_grad=True)
+                        children_h_var = Variable(torch.zeros(self.max_num_children, self.mem_dim),
+                                                  requires_grad=True)
+                        if cuda.is_available():
+                            children_c_var = children_c_var.cuda()
+                            children_h_var = children_h_var.cuda()
+                        children_c_var[:len(children_c)] = torch.cat(children_c, dim=0)
+                        children_h_var[:len(children_h)] = torch.cat(children_h, dim=0)
+                        queue.append((tree_idx, parent_node.idx, inputs[tree_idx][parent_node.idx],
+                                     children_c_var, children_h_var))
+                head += 1
+
+            depth += 1
+            # update parent states
+            newhead = prev_num_nodes
+            while newhead < len(queue):
+                encoder_inputs, children_c, children_h, num_children = [], [], [], []
+                while newhead < len(queue) and len(encoder_inputs) < self.bsz:
+                    tree_idx, node_idx, input, child_c, child_h = queue[newhead]
+                    curr_node = trees[tree_idx][node_idx]
+                    encoder_inputs.append(input.unsqueeze(0))
+                    children_c.append(child_c.unsqueeze(0))
+                    children_h.append(child_h.unsqueeze(0))
+                    num_children.append(curr_node.num_children)
+                    newhead += 1
+                if len(encoder_inputs) > 0:
+                    encoder_inputs = torch.cat(encoder_inputs, dim=0)
+                    children_c = torch.cat(children_c, dim=0)
+                    children_h = torch.cat(children_h, dim=0)
+                    num_internal_nodes += len(encoder_inputs)
+                    #print('internal', len(encoder_inputs))
+                    batch_c, batch_h = self.batch_node_forward(
+                        encoder_inputs, children_c, children_h, num_children
+                    )
+                    for i in range(batch_c.shape[0]):
+                        idx = newhead - batch_c.shape[0] + i
+                        tree_idx, node_idx, _, _, _ = queue[idx]
+                        trees[tree_idx][node_idx].state = (batch_c[i], batch_h[i])
+            for index in range(prev_num_nodes, len(queue)):
+                tree_idx, node_idx, _, _, _ = queue[idx]
+                assert trees[tree_idx][node_idx].state is not None
+        #print("num of internal nodes", num_internal_nodes)
+
+
+    def batch_forward(self, trees, inputs):
+        # trees: list[list[tree]]
+        # inputs: list[torch.Tensor(seqlen, emb_size)]
+        num_nodes = {}
+        for tree_idx, tree in enumerate(trees):
+            for node_idx, node in tree.items():
+                assert node.state is None
+                assert not node.visited
+                depth = node.depth()
+                if depth not in num_nodes:
+                    num_nodes[depth] = 0
+                num_nodes[depth] += 1
+        # print(num_nodes)
+        queue = self.update_leaf_states(trees, inputs)
+        self.update_internal_node_states(trees, inputs, queue)
+        root_c, root_h = [], []
+        for tree in trees:
+            root = Tree.get_root(tree[0])
+            root_c.append(root.state[0].unsqueeze(0))
+            root_h.append(root.state[1].unsqueeze(0))
+        for tree_idx, tree in enumerate(trees):
+            for node_idx, node in tree.items():
+                assert node.state is not None
+                assert node.visited
+        return torch.cat(root_c, dim=0), torch.cat(root_h, dim=0)
 
 
 # module for distance-angle similarity
@@ -79,9 +246,21 @@ class SimilarityTreeLSTM(nn.Module):
         self.similarity = Similarity(mem_dim, hidden_dim, num_classes)
 
     def forward(self, ltree, linputs, rtree, rinputs):
+        if isinstance(ltree, list):
+            return self.batch_forward(ltree, linputs, rtree, rinputs)
         linputs = self.emb(linputs)
         rinputs = self.emb(rinputs)
         lstate, lhidden = self.childsumtreelstm(ltree, linputs)
         rstate, rhidden = self.childsumtreelstm(rtree, rinputs)
         output = self.similarity(lstate, rstate)
+        return output
+
+    def batch_forward(self, ltrees, linputs, rtrees, rinputs):
+        linputs_tensor, rinputs_tensor = [], []
+        for i in range(len(linputs)):
+            linputs_tensor.append(self.emb(linputs[i]))
+            rinputs_tensor.append(self.emb(rinputs[i]))
+        lstates, lhidden = self.childsumtreelstm(ltrees, linputs_tensor)
+        rstates, rhidden = self.childsumtreelstm(rtrees, rinputs_tensor)
+        output = self.similarity(lstates, rstates)
         return output

--- a/treelstm/trainer.py
+++ b/treelstm/trainer.py
@@ -5,6 +5,17 @@ import torch
 from . import utils
 
 
+def get_avg_grad(named_parameters):
+    layers, avg_data, avg_grads = [], [], []
+    for name, param in named_parameters:
+        if (param.requires_grad) and ("bias" not in name):
+            layers.append(name)
+            avg_data.append(param.data.abs().mean())
+            if param.grad is not None:
+                avg_grads.append(param.grad.abs().mean())
+    return layers, avg_data, avg_grads
+
+
 class Trainer(object):
     def __init__(self, args, model, criterion, optimizer, device):
         super(Trainer, self).__init__()
@@ -15,24 +26,61 @@ class Trainer(object):
         self.device = device
         self.epoch = 0
 
+    def clear_states(self, trees):
+        for tree_idx, tree in enumerate(trees):
+            for node_idx, node in tree.items():
+                assert node.state is not None
+                assert node.visited
+                node.state = None
+                node.visited = False
+
     # helper function for training
     def train(self, dataset):
         self.model.train()
         self.optimizer.zero_grad()
         total_loss = 0.0
         indices = torch.randperm(len(dataset), dtype=torch.long, device='cpu')
-        for idx in tqdm(range(len(dataset)), desc='Training epoch ' + str(self.epoch + 1) + ''):
-            ltree, linput, rtree, rinput, label = dataset[indices[idx]]
-            target = utils.map_label_to_target(label, dataset.num_classes)
-            linput, rinput = linput.to(self.device), rinput.to(self.device)
-            target = target.to(self.device)
-            output = self.model(ltree, linput, rtree, rinput)
-            loss = self.criterion(output, target)
-            total_loss += loss.item()
-            loss.backward()
-            if idx % self.args.batchsize == 0 and idx > 0:
+        if not self.args.use_batch:
+            for idx in range(len(dataset)):
+                ltree, linput, rtree, rinput, label = dataset[indices[idx]]
+                lroot, ltree = ltree[0], ltree[1]
+                rroot, rtree = rtree[0], rtree[1]
+                target = utils.map_label_to_target(label, dataset.num_classes)
+                linput, rinput = linput.to(self.device), rinput.to(self.device)
+                target = target.to(self.device)
+                output = self.model(lroot, linput, rroot, rinput)
+                loss = self.criterion(output, target)
+                total_loss += loss.sum()
+                loss.sum().backward()
+                if (idx + 1) % self.args.batchsize == 0 and idx > 0:
+                    self.optimizer.step()
+                    self.optimizer.zero_grad()
+        else:
+            for idx in range(0, len(dataset), self.args.batchsize):
+                ltrees, rtrees, linputs, rinputs, labels = [], [], [], [], []
+                for new_index in indices[idx: min(len(dataset), idx+self.args.batchsize)]:
+                    ltree, lsent, rtree, rsent, label = dataset[new_index]
+                    ltrees.append(ltree[1])
+                    rtrees.append(rtree[1])
+                    linputs.append(lsent)
+                    rinputs.append(rsent)
+                    labels.append(label)
+
+                targets = []
+                for i in range(len(linputs)):
+                    linputs[i] = linputs[i].to(self.device)
+                    rinputs[i] = rinputs[i].to(self.device)
+                    target = utils.map_label_to_target(labels[i], dataset.num_classes)
+                    targets.append(target.to(self.device))
+                targets = torch.cat(targets, dim=0)
+                outputs = self.model(ltrees, linputs, rtrees, rinputs)
+                loss = self.criterion(outputs, targets)
+                total_loss += loss.sum()
+                loss.sum().backward()
                 self.optimizer.step()
                 self.optimizer.zero_grad()
+                self.clear_states(ltrees)
+                self.clear_states(rtrees)
         self.epoch += 1
         return total_loss / len(dataset)
 
@@ -42,15 +90,38 @@ class Trainer(object):
         with torch.no_grad():
             total_loss = 0.0
             predictions = torch.zeros(len(dataset), dtype=torch.float, device='cpu')
-            indices = torch.arange(1, dataset.num_classes + 1, dtype=torch.float, device='cpu')
-            for idx in tqdm(range(len(dataset)), desc='Testing epoch  ' + str(self.epoch) + ''):
-                ltree, linput, rtree, rinput, label = dataset[idx]
-                target = utils.map_label_to_target(label, dataset.num_classes)
-                linput, rinput = linput.to(self.device), rinput.to(self.device)
-                target = target.to(self.device)
-                output = self.model(ltree, linput, rtree, rinput)
-                loss = self.criterion(output, target)
-                total_loss += loss.item()
-                output = output.squeeze().to('cpu')
-                predictions[idx] = torch.dot(indices, torch.exp(output))
+            if not self.args.use_batch:
+                indices = torch.arange(1, dataset.num_classes + 1, dtype=torch.float, device='cpu')
+                for idx in range(len(dataset)):
+                    ltree, linput, rtree, rinput, label = dataset[idx]
+                    lroot, ltree = ltree[0], ltree[1]
+                    rroot, rtree = rtree[0], rtree[1]
+                    target = utils.map_label_to_target(label, dataset.num_classes)
+                    linput, rinput = linput.to(self.device), rinput.to(self.device)
+                    target = target.to(self.device)
+                    output = self.model(lroot, linput, rroot, rinput)
+                    loss = self.criterion(output, target)
+                    total_loss += loss.sum()
+                    output = output.squeeze().to('cpu')
+                    predictions[idx] = torch.dot(indices, torch.exp(output))
+            else:
+                indices = torch.arange(1, dataset.num_classes + 1, dtype=torch.float, device='cpu')
+                for idx in range(0, len(dataset), self.args.batchsize):
+                    ltrees, linputs, rtrees, rinputs, labels = dataset.get_next_batch(idx, self.args.batchsize)
+                    targets = []
+                    for i in range(len(linputs)):
+                        linputs[i] = linputs[i].to(self.device)
+                        rinputs[i] = rinputs[i].to(self.device)
+                        target = utils.map_label_to_target(labels[i], dataset.num_classes)
+                        targets.append(target.to(self.device))
+                    targets = torch.cat(targets, dim=0)
+                    outputs = self.model(ltrees, linputs, rtrees, rinputs)
+                    losses = self.criterion(outputs, targets)
+                    total_loss += losses.sum()
+                    outputs = outputs.to('cpu')
+                    batch_indices = indices.repeat(len(ltrees), 1)
+                    predictions[idx: idx+len(ltrees)] = \
+                        (batch_indices * torch.exp(outputs)).sum(dim=1, keepdim=False)
+                    self.clear_states(ltrees)
+                    self.clear_states(rtrees)
         return total_loss / len(dataset), predictions

--- a/treelstm/tree.py
+++ b/treelstm/tree.py
@@ -2,6 +2,9 @@
 class Tree(object):
     def __init__(self):
         self.parent = None
+        self.state = None
+        self.idx = -1
+        self.visited = False
         self.num_children = 0
         self.children = list()
 
@@ -9,6 +12,13 @@ class Tree(object):
         child.parent = self
         self.num_children += 1
         self.children.append(child)
+
+    @staticmethod
+    def get_root(node):
+        if node.parent is None:
+            return node
+        else:
+            return Tree.get_root(node.parent)
 
     def size(self):
         if getattr(self, '_size'):
@@ -20,8 +30,8 @@ class Tree(object):
         return self._size
 
     def depth(self):
-        if getattr(self, '_depth'):
-            return self._depth
+        #if getattr(self, '_depth'):
+        #    return self._depth
         count = 0
         if self.num_children > 0:
             for i in range(self.num_children):


### PR DESCRIPTION
Existing implementation doesn't support forward/backward with batch of trees as inputs, which is slow in training and inference. The pull requests support batch operation for TreeLSTM, and reproduces the *exact* same results as without batch.

To run with batch:
```
- python main.py --use_batch
```